### PR TITLE
feat: Eslint, Prettier 통합

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "bracketSpacing": true
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,8 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import next from "eslint-config-next";
+import prettier from "eslint-config-prettier";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -10,6 +12,13 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  next,
+  {
+    rules: {
+      // Prettier 규칙을 ESLint가 위반으로 인식하도록
+      ...prettier.rules,
+    },
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,10 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "eslint": "^9",
+        "eslint": "^9.29.0",
         "eslint-config-next": "15.3.4",
+        "eslint-config-prettier": "^10.1.5",
+        "prettier": "^3.5.3",
         "prettier-plugin-tailwindcss": "^0.6.13",
         "tailwindcss": "^4",
         "typescript": "^5"
@@ -2870,6 +2872,22 @@
         }
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -5055,7 +5073,6 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "eslint": "^9",
+    "eslint": "^9.29.0",
     "eslint-config-next": "15.3.4",
+    "eslint-config-prettier": "^10.1.5",
+    "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.13",
     "tailwindcss": "^4",
     "typescript": "^5"


### PR DESCRIPTION
## 1. npm install -D eslint-config-prettier 
Prettier와 충돌하는 ESLint 규칙들을 꺼주는 ESLint 설정 패키지를 설치하는 과정
ESLint는 “스타일 검사 도구”, Prettier는 “스타일 포맷터”
둘 다 코드 스타일을 다루기 때문에 Prettier가 담당할 부분은 ESLint에게 검사하지 말라고 지시하는 작업이 필요함.

> 그렇다면 왜 같이 쓰는가?
<img width="1021" alt="스크린샷 2025-06-21 오후 5 29 32" src="https://github.com/user-attachments/assets/f402145e-b655-473f-9236-eac49c9fe59b" />

## 2.  eslint.config.mjs 파일 수정
```javascript
import { dirname } from "path";
import { fileURLToPath } from "url";
import { FlatCompat } from "@eslint/eslintrc";
import next from "eslint-config-next";
import prettier from "eslint-config-prettier";

const __filename = fileURLToPath(import.meta.url);
const __dirname = dirname(__filename);

const compat = new FlatCompat({
  baseDirectory: __dirname,
});

const eslintConfig = [
  next,
  {
    rules: {
      // Prettier 규칙을 ESLint가 위반으로 인식하도록
      ...prettier.rules,
    },
  },
  ...compat.extends("next/core-web-vitals", "next/typescript"),
];

export default eslintConfig;

```

## 3. .prettierrc 파일 추가

```
{
  "semi": true,
  "singleQuote": false,
  "tabWidth": 2,
  "trailingComma": "all",
  "printWidth": 100,
  "bracketSpacing": true
}

```

## Preview

https://github.com/user-attachments/assets/734058f9-1e7c-4caa-9eaa-f64cacb046ab

