### PR TITLE
feat: 로그인 회원가입 api 연결 + token 관리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "thedream",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.10.0",
         "clsx": "^2.1.1",
         "next": "15.3.4",
         "react": "^19.0.0",
@@ -2149,6 +2150,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2173,6 +2180,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2250,7 +2268,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2392,6 +2409,18 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/concat-map": {
@@ -2545,6 +2574,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2572,7 +2610,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2677,7 +2714,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2687,7 +2723,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2725,7 +2760,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2738,7 +2772,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3361,6 +3394,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3377,11 +3430,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3422,7 +3490,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3447,7 +3514,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3535,7 +3601,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3614,7 +3679,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3627,7 +3691,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3643,7 +3706,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4557,7 +4619,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4585,6 +4646,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5184,6 +5266,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "axios": "^1.10.0",
     "clsx": "^2.1.1",
     "next": "15.3.4",
     "react": "^19.0.0",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,0 +1,26 @@
+import axios from "axios";
+
+// 인증절차가 필요없는 HTTP 요청을 할 때 사용하는 인스턴스
+const instance = axios.create({
+  baseURL: "https://front-mission.bigs.or.kr/", //원래는 환경변수화 하는 것이 Best Pracitce이나, 이번 과제에서는 생략하였습니다.
+  timeout: 5000,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// 인증절차가 필요한 HTTP 요청을 할 때 사용하는 인스턴스
+const authInstance = axios.create({
+  baseURL: "https://front-mission.bigs.or.kr/",
+  timeout: 5000,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// intercpetors를 사용하여 기존에 설정값에 header에 accessToken을 추가해주는 작업을 추상화
+authInstance.interceptors.request.use((config) => {
+  const token = localStorage.getItem("accessToken");
+  if (token) config.headers.Authorization = `Bearer ${token}`;
+  return config;
+});

--- a/src/api/postSignIn.ts
+++ b/src/api/postSignIn.ts
@@ -1,14 +1,5 @@
 import axios, { AxiosResponse } from "axios";
-
-interface SignInPayload {
-  username: string;
-  password: string;
-}
-
-interface SignInResponse {
-  accessToken: string;
-  refreshToken: string;
-}
+import { SignInPayload, SignInResponse } from "@/types/auth";
 
 export const postSignIn = async (body: SignInPayload): Promise<AxiosResponse<SignInResponse>> => {
   return await axios.post("/api/auth/signin", body);

--- a/src/api/postSignIn.ts
+++ b/src/api/postSignIn.ts
@@ -1,5 +1,4 @@
-import { AxiosResponse } from "axios";
-import { instance } from "@/lib/axios";
+import axios, { AxiosResponse } from "axios";
 
 interface SignInPayload {
   username: string;
@@ -12,5 +11,5 @@ interface SignInResponse {
 }
 
 export const postSignIn = async (body: SignInPayload): Promise<AxiosResponse<SignInResponse>> => {
-  return await instance.post("/auth/signin", body);
+  return await axios.post("/api/auth/signin", body);
 };

--- a/src/api/postSignIn.ts
+++ b/src/api/postSignIn.ts
@@ -1,0 +1,16 @@
+import { AxiosResponse } from "axios";
+import { instance } from "@/lib/axios";
+
+interface SignInPayload {
+  username: string;
+  password: string;
+}
+
+interface SignInResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export const postSignIn = async (body: SignInPayload): Promise<AxiosResponse<SignInResponse>> => {
+  return await instance.post("/auth/signin", body);
+};

--- a/src/api/postSignUp.ts
+++ b/src/api/postSignUp.ts
@@ -1,12 +1,6 @@
 import { AxiosResponse } from "axios";
 import { instance } from "@/lib/axios";
-
-interface SignUpPayload {
-  username: string;
-  name: string;
-  password: string;
-  confirmPassword: string;
-}
+import { SignUpPayload } from "@/types/auth";
 
 export const postSignUp = async (body: SignUpPayload): Promise<AxiosResponse<void>> => {
   return await instance.post("/auth/signup", body);

--- a/src/api/postSignUp.ts
+++ b/src/api/postSignUp.ts
@@ -1,0 +1,13 @@
+import { AxiosResponse } from "axios";
+import { instance } from "@/lib/axios";
+
+interface SignUpPayload {
+  username: string;
+  name: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export const postSignUp = async (body: SignUpPayload): Promise<AxiosResponse<void>> => {
+  return await instance.post("/auth/signup", body);
+};

--- a/src/app/api/auth/signin/route.ts
+++ b/src/app/api/auth/signin/route.ts
@@ -5,8 +5,6 @@ import { SignInResponse } from "@/types/auth";
 export async function POST(req: Request) {
   const payload = await req.json();
 
-  console.log(payload);
-
   try {
     const res = await instance.post<SignInResponse>("/auth/signin", payload);
     const { refreshToken, accessToken } = res.data;

--- a/src/app/api/auth/signin/route.ts
+++ b/src/app/api/auth/signin/route.ts
@@ -1,0 +1,27 @@
+import { cookies } from "next/headers";
+import { instance } from "@/lib/axios";
+import { SignInResponse } from "@/types/auth";
+
+export async function POST(req: Request) {
+  const payload = await req.json();
+
+  console.log(payload);
+
+  try {
+    const res = await instance.post<SignInResponse>("/auth/signin", payload);
+    const { refreshToken, accessToken } = res.data;
+
+    cookies().set("refreshToken", refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 14,
+    });
+
+    return Response.json({ accessToken });
+  } catch (err) {
+    console.error("sigin route 에러", err);
+    throw new Error("signin route 서버에서 로그인 요청 중 에러가 발생했습니다.");
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,8 +5,22 @@ import { useEffect } from "react";
 
 export default function Home() {
   const router = useRouter();
+
   useEffect(() => {
-    router.push("/signin");
+    const auth = localStorage.getItem("auth");
+
+    if (auth) {
+      const currentTime = Date.now();
+      const { expiresAt } = JSON.parse(auth);
+
+      if (currentTime > expiresAt) {
+        localStorage.removeItem("auth");
+        alert("로그인 세션이 만료되었습니다. 다시 로그인 해주세요.");
+        router.push("/signin");
+      } else {
+        router.push("/boards");
+      }
+    } else router.push("/signin");
   }, [router]);
 
   return null;

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import AuthButton from "@/components/button/AuthButton";
 import FormInput from "@/components/input/FormInput";
+import { postSignIn } from "@/api/postSignIn";
 
 export default function SignInPage() {
   const {
@@ -15,7 +16,16 @@ export default function SignInPage() {
     formState: { errors },
   } = useForm<SignInPayload>({ mode: "onBlur" });
 
-  const onSubmit = async (body: SignInPayload) => {};
+  const onSubmit = async (body: SignInPayload) => {
+    try {
+      const res = await postSignIn(body);
+      const { accessToken } = res.data;
+      localStorage.setItem("accessToken", accessToken);
+      alert("로그인에 성공했습니다.");
+    } catch (err) {
+      alert("로그인에 실패했습니다.");
+    }
+  };
 
   return (
     <section className="w-[343px] h-auto flex flex-col items-center justify-center bg-white shadow-xl rounded-lg p-8">

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { SignInPayload } from "@/types/auth";
+import { postSignIn } from "@/api/postSignIn";
 import Image from "next/image";
 import Link from "next/link";
 import AuthButton from "@/components/button/AuthButton";
 import FormInput from "@/components/input/FormInput";
-import { postSignIn } from "@/api/postSignIn";
 
 export default function SignInPage() {
   const {
@@ -16,12 +17,23 @@ export default function SignInPage() {
     formState: { errors },
   } = useForm<SignInPayload>({ mode: "onBlur" });
 
+  const router = useRouter();
+
   const onSubmit = async (body: SignInPayload) => {
     try {
       const res = await postSignIn(body);
       const { accessToken } = res.data;
-      localStorage.setItem("accessToken", accessToken);
-      alert("로그인에 성공했습니다.");
+      const expiresAt = Date.now() + 1000 * 60 * 15; //AccessToken이 로컬스토리지에서 만료되어야 하는 시각
+
+      localStorage.setItem(
+        "auth",
+        JSON.stringify({
+          accessToken,
+          expiresAt,
+        }),
+      );
+      alert("로그인에 성공했습니다. 홈페이지로 이동합니다.");
+      router.push("/");
     } catch (err) {
       alert("로그인에 실패했습니다.");
     }

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,15 +1,11 @@
 "use client";
 
 import { useForm } from "react-hook-form";
+import { SignInPayload } from "@/types/auth";
 import Image from "next/image";
 import Link from "next/link";
 import AuthButton from "@/components/button/AuthButton";
 import FormInput from "@/components/input/FormInput";
-
-interface SignInFormValues {
-  id: string;
-  password: string;
-}
 
 export default function SignInPage() {
   const {
@@ -17,9 +13,9 @@ export default function SignInPage() {
     handleSubmit,
     clearErrors,
     formState: { errors },
-  } = useForm<SignInFormValues>({ mode: "onBlur" });
+  } = useForm<SignInPayload>({ mode: "onBlur" });
 
-  const onSubmit = async () => {};
+  const onSubmit = async (body: SignInPayload) => {};
 
   return (
     <section className="w-[343px] h-auto flex flex-col items-center justify-center bg-white shadow-xl rounded-lg p-8">
@@ -31,15 +27,15 @@ export default function SignInPage() {
             label="아이디"
             type="text"
             placeholder="아이디를 입력해 주세요."
-            register={register("id", {
+            register={register("username", {
               required: "아이디는 필수입니다.",
               pattern: {
                 value: /^[^\s@]+@[^\s@]+\.(com|net)$/,
                 message: "이메일 형식으로 입력해주세요.",
               },
-              onChange: () => clearErrors("id"),
+              onChange: () => clearErrors("username"),
             })}
-            error={errors.id}
+            error={errors.username}
           />
 
           <FormInput

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,16 +1,13 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
+import { postSignUp } from "@/api/postSignUp";
+import { SignUpPayload } from "@/types/auth";
 import Link from "next/link";
 import AuthButton from "@/components/button/AuthButton";
 import FormInput from "@/components/input/FormInput";
 
-interface SignUpFormValues {
-  name: string;
-  id: string;
-  password: string;
-  passwordConfirm: string;
-}
 export default function SignUpPage() {
   const {
     register,
@@ -18,9 +15,22 @@ export default function SignUpPage() {
     clearErrors,
     watch,
     formState: { errors },
-  } = useForm<SignUpFormValues>({ mode: "onBlur" });
+  } = useForm<SignUpPayload>({ mode: "onBlur" });
 
-  const onSubmit = async () => {};
+  const router = useRouter();
+
+  const onSubmit = async (data: SignUpPayload) => {
+    try {
+      const res = await postSignUp(data);
+      if (res.status >= 200 && res.status < 300) {
+        alert("회원가입에 성공했습니다. 다시 로그인 해주세요.");
+        router.push("/signin");
+      }
+    } catch (err) {
+      console.error("회원가입 실패", err);
+      alert("회원가입에 실패했습니다.");
+    }
+  };
 
   return (
     <section className="w-[343px] h-auto flex flex-col items-center justify-center bg-white shadow-xl rounded-lg p-8">
@@ -42,19 +52,19 @@ export default function SignUpPage() {
             error={errors.name}
           />
           <FormInput
-            id="id"
+            id="username"
             label="아이디"
             type="text"
             placeholder="아이디를 입력해 주세요."
-            register={register("id", {
+            register={register("username", {
               required: "아이디는 필수입니다.",
               pattern: {
                 value: /^[^\s@]+@[^\s@]+\.(com|net)$/,
                 message: "이메일 형식으로 입력해주세요.",
               },
-              onChange: () => clearErrors("id"),
+              onChange: () => clearErrors("username"),
             })}
-            error={errors.id}
+            error={errors.username}
           />
           <FormInput
             id="password"
@@ -72,16 +82,16 @@ export default function SignUpPage() {
             error={errors.password}
           />
           <FormInput
-            id="passwordConfirm"
+            id="confirmPassword"
             label="비밀번호 확인"
             type="password"
             placeholder="비밀번호를 입력해 주세요."
-            register={register("passwordConfirm", {
+            register={register("confirmPassword", {
               required: "비밀번호는 필수입니다.",
               validate: (value) => value === watch("password") || "비밀번호가 일치하지 않습니다.",
-              onChange: () => clearErrors("passwordConfirm"),
+              onChange: () => clearErrors("confirmPassword"),
             })}
-            error={errors.passwordConfirm}
+            error={errors.confirmPassword}
           />
           <AuthButton type="회원가입" />
         </form>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -24,6 +24,10 @@ export default function SignUpPage() {
       const res = await postSignUp(data);
       if (res.status >= 200 && res.status < 300) {
         alert("회원가입에 성공했습니다. 다시 로그인 해주세요.");
+        localStorage.setItem(
+          "profile",
+          JSON.stringify({ name: data.name, username: data.username }),
+        );
         router.push("/signin");
       }
     } catch (err) {

--- a/src/components/input/FormInput.tsx
+++ b/src/components/input/FormInput.tsx
@@ -15,7 +15,7 @@ interface FormInputProps {
 }
 
 const FormInput = ({ id, label, type = "text", placeholder, register, error }: FormInputProps) => {
-  const isPasswordInput = type === "password" || type === "passwordConfirm";
+  const isPasswordInput = type === "password" || type === "confirmPassword";
   const [view, setView] = useState(false);
 
   const togglePasswordView = (e: MouseEvent<HTMLButtonElement>) => {

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 // 인증절차가 필요없는 HTTP 요청을 할 때 사용하는 인스턴스
-const instance = axios.create({
+export const instance = axios.create({
   baseURL: "https://front-mission.bigs.or.kr/", //원래는 환경변수화 하는 것이 Best Pracitce이나, 이번 과제에서는 생략하였습니다.
   timeout: 5000,
   headers: {
@@ -10,7 +10,7 @@ const instance = axios.create({
 });
 
 // 인증절차가 필요한 HTTP 요청을 할 때 사용하는 인스턴스
-const authInstance = axios.create({
+export const authInstance = axios.create({
   baseURL: "https://front-mission.bigs.or.kr/",
   timeout: 5000,
   headers: {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,11 @@
+export interface SignInPayload {
+  username: string;
+  password: string;
+}
+
+export interface SignUpPayload {
+  name: string;
+  username: string;
+  password: string;
+  confirmPassword: string;
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,12 +1,14 @@
+interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
 export interface SignInPayload {
   username: string;
   password: string;
 }
 
-export interface SignInResponse {
-  accessToken: string;
-  refreshToken: string;
-}
+export type SignInResponse = TokenPair;
 
 export interface SignUpPayload {
   name: string;
@@ -15,7 +17,4 @@ export interface SignUpPayload {
   confirmPassword: string;
 }
 
-export interface RefreshTokenResponse {
-  accessToken: string;
-  refreshToken: string;
-}
+export type RefreshTokenResponse = TokenPair;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -14,3 +14,8 @@ export interface SignUpPayload {
   password: string;
   confirmPassword: string;
 }
+
+export interface RefreshTokenResponse {
+  accessToken: string;
+  refreshToken: string;
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -3,6 +3,11 @@ export interface SignInPayload {
   password: string;
 }
 
+export interface SignInResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
 export interface SignUpPayload {
   name: string;
   username: string;


### PR DESCRIPTION
#9 

## 작업한 내용 
1.  인증이 필요없는 axios 요청은 instance, 필요한 요청은 authInstance 객체를 이용하도록 인스턴스화 해주었습니다.

2. authInstance는 interceptor 기능을 활용해 응답 상태 코드가 401일 경우, 인증 토큰이 만료되었다고 간주하고, refreshToken을 사용해 accessToken을 재갱신하는 로직을 수행하도록 했습니다.

3. 회원가입 시에는 로컬 스토리지에 username과 name을 하나의 profile key에 저장하고, 로그인 페이지로 리다이렉트 시킵니다.

4. 로그인 페이지로 들어와 로그인에 성공하면, 만들어 둔 api 함수인 postSignIn을 호출합니다. 특이한 점은 클라이언트에서 바로 백엔드로 요청을 보내는 것이 아닌 api route 로 요청을 보내 마지막에 클라이언트는 accessToken만 받도록 했습니다. api route가 하는 역할은 다음과 같습니다.
- 사용자에게 POST 요청이 들어오면 백엔드 주소로 post 요청을 보냅니다.
- post 요청에 성공하면 로그인에 성공했다는 뜻이므로, refreshToken과 accessToken을 받습니다.
- refreshToken은 HttpOnly 옵션 쿠키에 저장하고, 클라이언트에게는 accessToken만 전해줍니다. 
- 이로써 생명주기가 길고, 탈취되었을 떄 보안성이 민감한 refreshToken은 비교적 안전한 서버가 관리하게 하고, HttpOnly 옵션과 SameSite 옵션을 달아주어 XSS CSRF 공격으로부터 보호합니다.

5. accessToken을 로컬 스토리지에 저장할때 유통기한도 같이 적어줍니다.(15분) 

6. 사용자가 Home에 접속했을 때 useEffect로 로컬 스토리지에 auth 값을 확인하여, 현재 시간이 유통기한 보다 지난 경우라면, 로컬 스토리지를 삭제하고 안내 문구와 함께 로그인 페이지로 이동 시킵니다.(그렇지 않다면 /boards 페이지로 이동시킵니다.)


## Preview
![로그인 시연](https://github.com/user-attachments/assets/75bea0db-1842-42d0-a7fd-6e745a0d508c)

