### PR TITLE
feat: "/boards" 페이지 카테고리별 필터링 spa 방식으로 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "next": "15.3.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-hook-form": "^7.58.1"
+        "react-hook-form": "^7.58.1",
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1328,7 +1329,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2449,7 +2450,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -6402,6 +6403,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.58.1"
+    "react-hook-form": "^7.58.1",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/api/getAllArticles.ts
+++ b/src/api/getAllArticles.ts
@@ -1,9 +1,9 @@
 import { authInstance } from "@/lib/axios";
 import { AxiosError } from "axios";
 
-const getAllArticles = async (page: number = 0, pageSize: number = 10) => {
+const getAllArticles = async (page: number = 1, pageSize: number = 10) => {
   try {
-    const res = await authInstance.get(`/boards?page=${page - 1}&size=${pageSize}`);
+    const res = await authInstance.get(`/boards?page=${page - 1}`);
     return res.data;
   } catch (err) {
     const axiosErr = err as AxiosError;

--- a/src/app/boards/components/ArticleList.tsx
+++ b/src/app/boards/components/ArticleList.tsx
@@ -11,28 +11,30 @@ const ArticleList = ({ list }: { list: BoardPreviewData[] }) => {
   };
 
   return (
-    <table className="w-full table-fixed text-center min-h-[350px]">
-      <thead className="text-center border-t-2 border-b">
-        <tr>
-          <th className="w-[10%] py-2">카테고리</th>
-          <th className="w-[70%]">제목</th>
-          <th className="w-[20%]">날짜</th>
-        </tr>
-      </thead>
-      <tbody className="text-sm">
-        {list.map((el) => (
-          <tr
-            key={el.id}
-            onClick={() => goDetailPage(el.id)}
-            className="border-b border-gray-300 text-gray-500 hover:bg-gray-100 cursor-pointer"
-          >
-            <td className="px-1 py-2 ">{el.category}</td>
-            <td className="px-1 py-2 text-left">{el.title}</td>
-            <td className="px-1 py-2 ">{isoStringToTime(el.createdAt)}</td>
+    <section className="h-[400px] w-[full]">
+      <table className="w-full text-center">
+        <thead className="border-t-2 border-b text-center">
+          <tr>
+            <th className="w-[10%] py-2">카테고리</th>
+            <th className="w-[70%]">제목</th>
+            <th className="w-[20%]">날짜</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody className="text-sm">
+          {list.map((el) => (
+            <tr
+              key={el.id}
+              onClick={() => goDetailPage(el.id)}
+              className="cursor-pointer border-b border-gray-300 text-gray-500 hover:bg-gray-100"
+            >
+              <td className="px-1 py-2">{el.category}</td>
+              <td className="px-1 py-2 text-left">{el.title}</td>
+              <td className="px-1 py-2">{isoStringToTime(el.createdAt)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
   );
 };
 

--- a/src/app/boards/components/BoardMain.tsx
+++ b/src/app/boards/components/BoardMain.tsx
@@ -1,28 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import { Article, Category } from "@/types/article";
 import Title from "@/app/boards/components/Title";
 import SearchArticleBar from "@/app/boards/components/SearchArticleBar";
 import ArticleList from "@/app/boards/components/ArticleList";
-import getAllArticles from "@/api/getAllArticles";
+import useInitializeArticles from "@/hook/useInitializeArticles";
+import useDisplayedArticlesByPage from "@/hook/useDisplayedArticlesByPage";
+import useDisplayedArticlesByCategory from "@/hook/useDisplayedArticlesByCategory";
 
-const BoardMain = async ({ currentPage }: { currentPage: number }) => {
-  let boardList = [];
+interface BoardMainProps {
+  currentPage: number;
+  category: string;
+}
 
-  try {
-    const res = await getAllArticles(Number(currentPage));
-    console.log("받아온 res는?", res.content);
+const BoardMain = ({ currentPage, category }: BoardMainProps) => {
+  const [displayedArticles, setDisplayedArticles] = useState<Article[]>([]);
 
-    boardList = res.content;
-    console.log("받아온 boardList", boardList);
-  } catch (err) {
-    console.error(err);
-  }
+  // 최초 마운트 시, 전역 store에 allArticles, ArticlesByCategory를 set해줌
+  useInitializeArticles();
+
+  // 페이지가 바뀔 때마다 displayedArticles를 업데이트 해줌
+  useDisplayedArticlesByPage(setDisplayedArticles, currentPage);
+
+  // category가 변경될 때마다 displayedArticles를 카테고리에 해당하는 내용으로 업데이트 해줌
+  useDisplayedArticlesByCategory(setDisplayedArticles, category as Category, currentPage);
 
   return (
     <div className="flex w-full max-w-[1200px] flex-col gap-6">
       <div className="flex items-center">
-        <Title content="전체" />
+        <Title category={category} />
         <SearchArticleBar />
       </div>
-      <ArticleList list={boardList} />
+      <ArticleList list={displayedArticles} />
     </div>
   );
 };

--- a/src/app/boards/components/Navigation.tsx
+++ b/src/app/boards/components/Navigation.tsx
@@ -1,61 +1,55 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 import clsx from "clsx";
 import Link from "next/link";
 
 const Navigation = () => {
-  const pathname = usePathname();
-
-  const isMainPage = pathname === "/boards";
-  const isNoticePage = pathname === "/boards/notice";
-  const isFreePage = pathname === "/boards/free";
-  const isQnaPage = pathname === "/boards/qna";
-  const isEtcPage = pathname === "/boards/etc";
+  const category = useParams().category;
 
   return (
-    <div className="flex gap-2 mr-auto">
+    <div className="mr-auto flex gap-2">
       <Link
         href="/boards"
         className={clsx(
-          "flex-1 text-lg font-bold h-full flex items-center text-[#4B5563] ml-6 hover:text-blue-400",
-          isMainPage ? "text-blue-400 pointer-events-none" : "",
+          "ml-6 flex h-full flex-1 items-center text-lg font-bold text-[#4B5563] hover:text-blue-400",
+          category === "all" ? "pointer-events-none text-blue-400" : "",
         )}
       >
         전체
       </Link>
       <Link
-        href="/boards/notice"
+        href="/boards?category=NOTICE"
         className={clsx(
-          "flex-1 text-lg font-bold h-full flex items-center text-[#4B5563] ml-6 hover:text-blue-400",
-          isNoticePage ? "text-blue-400 pointer-events-none" : "",
+          "ml-6 flex h-full flex-1 items-center text-lg font-bold text-[#4B5563] hover:text-blue-400",
+          category === "NOTICE" ? "pointer-events-none text-blue-400" : "",
         )}
       >
         공지
       </Link>
       <Link
-        href="/boards/free"
+        href="/boards?category=FREE"
         className={clsx(
-          "flex-1 text-lg font-bold h-full flex items-center text-[#4B5563] ml-6 hover:text-blue-400",
-          isFreePage ? "text-blue-400 pointer-events-none" : "",
+          "ml-6 flex h-full flex-1 items-center text-lg font-bold text-[#4B5563] hover:text-blue-400",
+          category === "FREE" ? "pointer-events-none text-blue-400" : "",
         )}
       >
         자유
       </Link>
       <Link
-        href="/boards/qna"
+        href="/boards?category=Q&A"
         className={clsx(
-          "flex-1 text-lg font-bold h-full flex items-center text-[#4B5563] ml-6 hover:text-blue-400",
-          isQnaPage ? "text-blue-400 pointer-events-none" : "",
+          "ml-6 flex h-full flex-1 items-center text-lg font-bold text-[#4B5563] hover:text-blue-400",
+          category === "Q&A" ? "pointer-events-none text-blue-400" : "",
         )}
       >
         질문
       </Link>
       <Link
-        href="/boards/etc"
+        href="/boards?category=ETC"
         className={clsx(
-          "flex-1 text-lg font-bold h-full flex items-center text-[#4B5563] ml-6 hover:text-blue-400",
-          isEtcPage ? "text-blue-400 pointer-events-none" : "",
+          "ml-6 flex h-full flex-1 items-center text-lg font-bold text-[#4B5563] hover:text-blue-400",
+          category === "ETC" ? "pointer-events-none text-blue-400" : "",
         )}
       >
         기타

--- a/src/app/boards/components/PaginationBar.tsx
+++ b/src/app/boards/components/PaginationBar.tsx
@@ -4,13 +4,13 @@ const PaginationBar = ({ currentPage }: { currentPage: number }) => {
   const list = ["<", "1", "2", "3", "4", "5", ">"];
 
   return (
-    <ol className="mx-auto flex gap-1 mt-8 ">
+    <ol className="mx-auto mt-8 flex gap-1">
       {list.map((el) => (
         <button
           key={el}
           className={clsx(
-            "rounded-full border-gray-300 border-1 font-semibold text-[#6B7280] flex justify-center items-center w-12 h-12 hover:bg-blue-400 hover:text-white",
-            currentPage === Number(el) ? "text-white bg-blue-400" : "",
+            "flex h-12 w-12 items-center justify-center rounded-full border-1 border-gray-300 font-semibold text-[#6B7280] hover:bg-blue-400 hover:text-white",
+            currentPage === Number(el) ? "bg-blue-400 text-white" : "",
           )}
         >
           {el}

--- a/src/app/boards/components/Title.tsx
+++ b/src/app/boards/components/Title.tsx
@@ -1,5 +1,28 @@
-const Title = ({ content }: { content: string }) => {
-  return <h1 className="text-2xl text-[#1F2937] font-bold">{content}</h1>;
+const Title = ({ category }: { category: string }) => {
+  let content = "전체";
+
+  switch (category) {
+    case "all":
+      content = "전체";
+      break;
+    case "notice":
+      content = "공지";
+      break;
+    case "free":
+      content = "자유";
+      break;
+    case "qna":
+      content = "Q&A";
+      break;
+    case "etc":
+      content = "기타";
+      break;
+    default:
+      content = "전체";
+      break;
+  }
+
+  return <h1 className="text-2xl font-bold text-[#1F2937]">{content}</h1>;
 };
 
 export default Title;

--- a/src/app/boards/components/Title.tsx
+++ b/src/app/boards/components/Title.tsx
@@ -2,19 +2,19 @@ const Title = ({ category }: { category: string }) => {
   let content = "전체";
 
   switch (category) {
-    case "all":
+    case "ALL":
       content = "전체";
       break;
-    case "notice":
+    case "NOTICE":
       content = "공지";
       break;
-    case "free":
+    case "FREE":
       content = "자유";
       break;
-    case "qna":
+    case "Q&A":
       content = "Q&A";
       break;
-    case "etc":
+    case "ETC":
       content = "기타";
       break;
     default:

--- a/src/app/boards/page.tsx
+++ b/src/app/boards/page.tsx
@@ -1,12 +1,20 @@
 import BoardMain from "@/app/boards/components/BoardMain";
 import PaginationBar from "@/app/boards/components/PaginationBar";
 
-const BoardsPage = async ({ searchParams }: { searchParams: { page: string } }) => {
+interface BoardsPageProps {
+  searchParams: {
+    page: string;
+    category: string;
+  };
+}
+
+const BoardsPage = async ({ searchParams }: BoardsPageProps) => {
   const page = Number(searchParams.page ?? "1");
+  const category = searchParams.category ?? "all";
 
   return (
-    <main className="relative flex flex-col justify-center w-full bg-white p-8 ">
-      <BoardMain currentPage={page} />
+    <main className="relative flex w-full flex-col justify-center bg-white p-8">
+      <BoardMain currentPage={page} category={category} />
       <PaginationBar currentPage={page} />
     </main>
   );

--- a/src/app/boards/page.tsx
+++ b/src/app/boards/page.tsx
@@ -10,7 +10,7 @@ interface BoardsPageProps {
 
 const BoardsPage = async ({ searchParams }: BoardsPageProps) => {
   const page = Number(searchParams.page ?? "1");
-  const category = searchParams.category ?? "all";
+  const category = searchParams.category ?? "ALL"; //notice, free,qna,etc
 
   return (
     <main className="relative flex w-full flex-col justify-center bg-white p-8">

--- a/src/hook/useDisplayedArticlesByCategory.ts
+++ b/src/hook/useDisplayedArticlesByCategory.ts
@@ -1,0 +1,20 @@
+import { Dispatch, SetStateAction, useEffect } from "react";
+import { useArticleStore } from "@/store/useArticleStore";
+import { Article, Category } from "@/types/article";
+import seperateArticlesByPage from "@/util/seperateArticlesByPage";
+
+const useDisplayedArticlesByCategory = (
+  setDisplayedArticles: Dispatch<SetStateAction<Article[]>>,
+  category: Category,
+  currentPage: number,
+) => {
+  useEffect(() => {
+    if (category == "all") return;
+    const { articlesByCategory } = useArticleStore.getState();
+    const filtered = articlesByCategory[category] || [];
+    const paged = seperateArticlesByPage(filtered, currentPage);
+    setDisplayedArticles(paged);
+  }, [category, currentPage]);
+};
+
+export default useDisplayedArticlesByCategory;

--- a/src/hook/useDisplayedArticlesByCategory.ts
+++ b/src/hook/useDisplayedArticlesByCategory.ts
@@ -8,12 +8,18 @@ const useDisplayedArticlesByCategory = (
   category: Category,
   currentPage: number,
 ) => {
+  const { allArticles } = useArticleStore();
+
   useEffect(() => {
-    if (category == "ALL") return;
-    const { articlesByCategory } = useArticleStore.getState();
-    const filtered = articlesByCategory[category] || [];
-    const paged = seperateArticlesByPage(filtered, currentPage);
-    setDisplayedArticles(paged);
+    // 카테고리가 all이면 전체 article을 보여주고, 그 외라면 category에 해당하는 article을 보여주기
+    if (category == "ALL") {
+      setDisplayedArticles(allArticles);
+    } else {
+      const { articlesByCategory } = useArticleStore.getState();
+      const filtered = articlesByCategory[category] || [];
+      const paged = seperateArticlesByPage(filtered, currentPage);
+      setDisplayedArticles(paged);
+    }
   }, [category, currentPage]);
 };
 

--- a/src/hook/useDisplayedArticlesByCategory.ts
+++ b/src/hook/useDisplayedArticlesByCategory.ts
@@ -9,7 +9,7 @@ const useDisplayedArticlesByCategory = (
   currentPage: number,
 ) => {
   useEffect(() => {
-    if (category == "all") return;
+    if (category == "ALL") return;
     const { articlesByCategory } = useArticleStore.getState();
     const filtered = articlesByCategory[category] || [];
     const paged = seperateArticlesByPage(filtered, currentPage);

--- a/src/hook/useDisplayedArticlesByPage.ts
+++ b/src/hook/useDisplayedArticlesByPage.ts
@@ -1,0 +1,19 @@
+import { Dispatch, SetStateAction, useEffect } from "react";
+import { useArticleStore } from "@/store/useArticleStore";
+import { Article } from "@/types/article";
+import seperateArticlesByPage from "@/util/seperateArticlesByPage";
+
+const useDisplayedArticlesByPage = (
+  setDisplayedArticles: Dispatch<SetStateAction<Article[]>>,
+  currentPage: number,
+) => {
+  const { allArticles } = useArticleStore.getState();
+
+  useEffect(() => {
+    if (allArticles.length === 0) return;
+    const articles = seperateArticlesByPage(allArticles, currentPage);
+    setDisplayedArticles(articles);
+  }, [currentPage, allArticles]);
+};
+
+export default useDisplayedArticlesByPage;

--- a/src/hook/useInitializeArticles.ts
+++ b/src/hook/useInitializeArticles.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { useArticleStore } from "@/store/useArticleStore";
+import { storeArticlesByCategory } from "@/util/storeArticleByCategory";
+import getAllArticles from "@/api/getAllArticles";
+
+const useInitializeArticles = () => {
+  const { setAllArticles } = useArticleStore();
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        const res = await getAllArticles();
+        setAllArticles(res.content);
+        storeArticlesByCategory(res.content);
+      } catch (err) {
+        console.error("geAllArticles 실행 도중 오류 발생", err);
+      }
+    };
+
+    fetch();
+  }, []);
+};
+
+export default useInitializeArticles;

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -22,9 +22,12 @@ authInstance.interceptors.request.use(async (config) => {
   const isClient = typeof window !== "undefined";
 
   if (isClient) {
-    const token = localStorage.getItem("accessToken");
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+    const accessToken = localStorage.getItem("auth")
+      ? JSON.parse(localStorage.getItem("auth")!).accessToken
+      : null;
+
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
     }
   } else {
     try {

--- a/src/store/useArticleStore.ts
+++ b/src/store/useArticleStore.ts
@@ -9,9 +9,15 @@ const initialState: ArticlesByCategory = {
 };
 
 export const useArticleStore = create<ArticleStore>((set, get) => ({
+  allArticles: [],
   articlesByCategory: initialState,
 
-  setArticles: (category, articles) =>
+  setAllArticles: (articles) =>
+    set(() => ({
+      allArticles: articles,
+    })),
+
+  setArticlesByCategory: (category, articles) =>
     set((state) => ({
       articlesByCategory: {
         ...state.articlesByCategory,

--- a/src/store/useArticleStore.ts
+++ b/src/store/useArticleStore.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+import { ArticlesByCategory, ArticleStore } from "@/types/article";
+
+const initialState: ArticlesByCategory = {
+  NOTICE: [],
+  FREE: [],
+  "Q&A": [],
+  ETC: [],
+};
+
+export const useArticleStore = create<ArticleStore>((set, get) => ({
+  articlesByCategory: initialState,
+
+  setArticles: (category, articles) =>
+    set((state) => ({
+      articlesByCategory: {
+        ...state.articlesByCategory,
+        [category]: articles,
+      },
+    })),
+
+  getArticles: (category) => get().articlesByCategory[category],
+}));

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -2,3 +2,20 @@ import { BoardData } from "@/types/boards";
 
 export type PostArticlePayload = BoardData;
 export type PatchArticlePayload = BoardData;
+
+export type ArticlesByCategory = {
+  [K in string]: Article[];
+};
+
+export interface Article {
+  id: number;
+  title: string;
+  category: string;
+  createdAt: string;
+}
+
+export interface ArticleStore {
+  articlesByCategory: ArticlesByCategory;
+  setArticles: (category: string, articles: Article[]) => void;
+  getArticles: (category: string) => Article[];
+}

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -5,7 +5,7 @@ export type PatchArticlePayload = BoardData;
 export type ArticlesByCategory = {
   [K in string]: Article[];
 };
-export type Category = "all" | "NOTICE" | "FREE" | "Q&A" | "ETC";
+export type Category = "NOTICE" | "FREE" | "Q&A" | "ETC";
 
 export interface Article {
   id: number;

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -5,7 +5,7 @@ export type PatchArticlePayload = BoardData;
 export type ArticlesByCategory = {
   [K in string]: Article[];
 };
-export type Category = "NOTICE" | "FREE" | "Q&A" | "ETC";
+export type Category = "NOTICE" | "FREE" | "Q&A" | "ETC" | "ALL";
 
 export interface Article {
   id: number;

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -2,20 +2,22 @@ import { BoardData } from "@/types/boards";
 
 export type PostArticlePayload = BoardData;
 export type PatchArticlePayload = BoardData;
-
 export type ArticlesByCategory = {
   [K in string]: Article[];
 };
+export type Category = "all" | "NOTICE" | "FREE" | "Q&A" | "ETC";
 
 export interface Article {
   id: number;
   title: string;
-  category: string;
+  category: Category;
   createdAt: string;
 }
 
 export interface ArticleStore {
+  allArticles: Article[];
   articlesByCategory: ArticlesByCategory;
-  setArticles: (category: string, articles: Article[]) => void;
+  setAllArticles: (articles: Article[]) => void;
+  setArticlesByCategory: (category: string, articles: Article[]) => void;
   getArticles: (category: string) => Article[];
 }

--- a/src/util/seperateArticlesByPage.ts
+++ b/src/util/seperateArticlesByPage.ts
@@ -1,0 +1,8 @@
+import { Article } from "@/types/article";
+
+const seperateArticlesByPage = (allArticles: Article[], page: number) => {
+  let startIndex = (page - 1) * 9;
+  return allArticles.slice(startIndex, startIndex + 10);
+};
+
+export default seperateArticlesByPage;

--- a/src/util/storeArticleByCategory.ts
+++ b/src/util/storeArticleByCategory.ts
@@ -18,6 +18,6 @@ export function storeArticlesByCategory(allArticles: Article[]) {
   const store = useArticleStore.getState();
 
   (Object.keys(categorized) as Category[]).forEach((category) => {
-    store.setArticles(category, categorized[category]);
+    store.setArticlesByCategory(category, categorized[category]);
   });
 }

--- a/src/util/storeArticleByCategory.ts
+++ b/src/util/storeArticleByCategory.ts
@@ -1,0 +1,23 @@
+import { useArticleStore } from "@/store/useArticleStore";
+import { Article, Category } from "@/types/article";
+
+export function storeArticlesByCategory(allArticles: Article[]) {
+  const categorized = {
+    NOTICE: [] as Article[],
+    FREE: [] as Article[],
+    "Q&A": [] as Article[],
+    ETC: [] as Article[],
+  };
+
+  allArticles.forEach((a) => {
+    if (categorized[a.category]) {
+      categorized[a.category].push(a);
+    }
+  });
+
+  const store = useArticleStore.getState();
+
+  (Object.keys(categorized) as Category[]).forEach((category) => {
+    store.setArticles(category, categorized[category]);
+  });
+}


### PR DESCRIPTION
#18 

## 📌 작업 개요
"/boards" 페이지에서 카테고리 클릭 시, 새로운 HTML을 받아오는 것이 아닌 동일한 페이지에서 ui만 다르게 보여주는 SPA 구현 작업이었습니다. 

## 🔨 주요 변경 사항
- page.tsx가 받는 searchParams에서 category가 추가되었습니다.
- Header에서 카테고리를 누르면, Link 컴포넌트가 category params를 추가한 url로 client side navgation 해줍니다.
- BoardMain 컴포넌트가 최초 마운트시 해주어야 하는 비즈니스 로직을 useInitializeArticles hook이 담당하도록 했습니다.
- 현재 페이지가 바뀔 떄마다 렌더링 할 데이터를 업데이트 해주는 로직을 useDisplayedArticlesByPage hook이 담당하도록 했습니다.
- category가 바뀔 떄마다 렌더링할 데이터를 업데이트 해주는 로직을 useDisplayedArticlesByCategory hook이 담당하도록 했습니다.

## 🧪 테스트 사항
- [x] Header에서 카테고리를 눌렀을 떄 알맞게 필터링 됩니다.
- [x] table에 요소가 일관적인 ui로 잘 배치됩니다.
- [x] table의 제목이 알맞게 바뀝니다.
- [ ]  페이지별로 데이터가 잘 받아져 옵니다. -> 페이지네이션 이슈 완료되면 작업 예정

## 🚀 트러블 슈팅
### 1. useEffect로 최초 mount시, 전체 목록 조회 데이터를 전역 store에 저장 
- 문제 분석
카테고리별로 GET 해올 수 있는 API가 따로 없어, 전체 목록을 조회한 후에 하드 코딩으로 필터링 해주어야 했습니다.
사용자가 카테고리를 누를 때마다, 전체 목록을 조회하는 것은 리소스 낭비이며, 네트워크 요청에 지연이 발생할 여지가 충분하다고 판단했습니다.
- 해결 
zustand를 사용하여, BoardMain 컴포넌트가 mount 시, 전체 게시글과 카테고리 게시글을 전역 객체에 저장해주었습니다.
상태가 업데이트가 필요한 시점에, 서버에 매번 재요청을 보내는 것이 아닌, 기존에 받아놨던 전역 store에 Articles를 참조합니다. 
(전체 -> allArticles, 카테고리 -> articlesByCategory)
- 부수효과 
Q. 사용자가 게시글을 새로 작성해, 최신화 된 데이터를 가져와야 하는 상황이 온다면?
두가지 방법을 생각해 봤습니다.
1. 사용자가 글쓰기하거나 삭제를 해 서버의 데이터가 갱신되면, window.reload로 새로고침 
2. react-query를 사용해, getAllArticles()의 response를 캐싱하고, 사용자가 CRUD 시에는 invalidateQueries() + refetchQueries() 를 사용해 캐시 무효화 + refetch 수행

시간 관셰아, 이번 프로젝트에서는 1번을 선택할 예정입니다.

## 🧑‍💻 남은 작업
- [ ] 트러블슈팅 1번의 부수효과를 해결하는 작업을 별도의 이슈에서 진행합니다.
- [ ] 페이지네이션 기능 구현 작업이 완료되면 페이지 별 조회도 잘 되는지 테스트 합니다.
