### PR TITLE
refactor: 토큰 재갱신 및 세션 유지 로직 개선

### DIFF
--- a/src/api/postLogout.ts
+++ b/src/api/postLogout.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const postLogout = async () => {
+  return await axios.post("/api/auth/logout");
+};
+
+export default postLogout;

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+
+export const POST = async () => {
+  const response = NextResponse.json(
+    { message: "정상적으로 로그아웃 되었습니다." },
+    { status: 200 },
+  );
+
+  response.cookies.set("accessToken", "", { maxAge: 0 });
+  response.cookies.set("refreshToken", "", { maxAge: 0 });
+
+  return response;
+};

--- a/src/app/api/auth/signin/route.ts
+++ b/src/app/api/auth/signin/route.ts
@@ -14,7 +14,7 @@ export async function POST(req: Request) {
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
       path: "/",
-      maxAge: 60 * 60 * 24 * 14,
+      maxAge: 60 * 5, // accessToken의 유효기간인 5분과 동일시
     });
 
     cookies().set("refreshToken", refreshToken, {
@@ -22,7 +22,7 @@ export async function POST(req: Request) {
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
       path: "/",
-      maxAge: 60 * 60 * 24 * 14,
+      maxAge: 60 * 60 * 24,
     });
 
     return Response.json({ accessToken });

--- a/src/app/boards/components/MyMenu.tsx
+++ b/src/app/boards/components/MyMenu.tsx
@@ -1,4 +1,22 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import postLogout from "@/api/postLogout";
+
 const MyMenu = () => {
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    try {
+      await postLogout();
+      alert("로그아웃 되었습니다.");
+      localStorage.removeItem("accessToken");
+      router.push("/signin");
+    } catch (err) {
+      console.error("로그아웃 실패:", err);
+    }
+  };
+
   return (
     <div className="absolute top-full right-0 z-50 mt-2 flex w-[170px] flex-col overflow-hidden rounded-lg border border-gray-200 bg-white text-black shadow-xl">
       <div className="flex h-[45%] w-full flex-col border-b-2 border-b-gray-200 p-4">
@@ -7,7 +25,9 @@ const MyMenu = () => {
       </div>
       <div className="h-[55%] w-full text-sm">
         <div className="h-[50%] px-4 py-2 hover:bg-gray-100">⚙️ 설정</div>
-        <div className="v h-[50%] px-4 py-2 text-red-400 hover:bg-gray-100">🚪 로그아웃</div>
+        <div className="v h-[50%] px-4 py-2 text-red-400 hover:bg-gray-100" onClick={handleLogout}>
+          🚪 로그아웃
+        </div>
       </div>
     </div>
   );

--- a/src/app/boards/components/MyMenu.tsx
+++ b/src/app/boards/components/MyMenu.tsx
@@ -1,0 +1,16 @@
+const MyMenu = () => {
+  return (
+    <div className="absolute top-full right-0 z-50 mt-2 flex w-[170px] flex-col overflow-hidden rounded-lg border border-gray-200 bg-white text-black shadow-xl">
+      <div className="flex h-[45%] w-full flex-col border-b-2 border-b-gray-200 p-4">
+        <span className="self-start">이름</span>
+        <span className="self-start">username</span>
+      </div>
+      <div className="h-[55%] w-full text-sm">
+        <div className="h-[50%] px-4 py-2 hover:bg-gray-100">⚙️ 설정</div>
+        <div className="v h-[50%] px-4 py-2 text-red-400 hover:bg-gray-100">🚪 로그아웃</div>
+      </div>
+    </div>
+  );
+};
+
+export default MyMenu;

--- a/src/app/boards/components/Profile.tsx
+++ b/src/app/boards/components/Profile.tsx
@@ -1,3 +1,8 @@
+"use client";
+
+import { useState } from "react";
+import MyMenu from "@/app/boards/components/MyMenu";
+
 const ProfileIcon = ({ className }: { className?: string }) => {
   return (
     <svg
@@ -16,8 +21,13 @@ const ProfileIcon = ({ className }: { className?: string }) => {
 };
 
 const Profile = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
-    <ProfileIcon className="size-10 hover:text-blue-400 text-gray-300 cursor-pointer transition-colors duration-75" />
+    <button onClick={() => setIsOpen((isOpen) => !isOpen)} className="relative">
+      <ProfileIcon className="size-10 cursor-pointer text-gray-300 transition-colors duration-75 hover:text-blue-400" />
+      {isOpen && <MyMenu />}
+    </button>
   );
 };
 

--- a/src/app/boards/page.tsx
+++ b/src/app/boards/page.tsx
@@ -13,7 +13,7 @@ const BoardsPage = async ({ searchParams }: BoardsPageProps) => {
   const category = searchParams.category ?? "ALL"; //notice, free,qna,etc
 
   return (
-    <main className="relative flex w-full flex-col justify-center bg-white p-8">
+    <main className="flex w-full flex-col justify-center bg-white p-8">
       <BoardMain currentPage={page} category={category} />
       <PaginationBar currentPage={page} />
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,27 +1,13 @@
-"use client";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+export default async function Home() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken");
 
-export default function Home() {
-  const router = useRouter();
-
-  useEffect(() => {
-    const auth = localStorage.getItem("auth");
-
-    if (auth) {
-      const currentTime = Date.now();
-      const { expiresAt } = JSON.parse(auth);
-
-      if (currentTime > expiresAt) {
-        localStorage.removeItem("auth");
-        alert("로그인 세션이 만료되었습니다. 다시 로그인 해주세요.");
-        router.push("/signin");
-      } else {
-        router.push("/boards");
-      }
-    } else router.push("/signin");
-  }, [router]);
-
-  return null;
+  if (accessToken) {
+    redirect("/boards");
+  } else {
+    redirect("/signin");
+  }
 }

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -23,15 +23,7 @@ export default function SignInPage() {
     try {
       const res = await postSignIn(body);
       const { accessToken } = res.data;
-      const expiresAt = Date.now() + 1000 * 60 * 15; //AccessToken이 로컬스토리지에서 만료되어야 하는 시각
-
-      localStorage.setItem(
-        "auth",
-        JSON.stringify({
-          accessToken,
-          expiresAt,
-        }),
-      );
+      localStorage.setItem("accessToken", accessToken);
       alert("로그인에 성공했습니다. 홈페이지로 이동합니다.");
       router.push("/");
     } catch (err) {
@@ -40,10 +32,10 @@ export default function SignInPage() {
   };
 
   return (
-    <section className="w-[343px] h-auto flex flex-col items-center justify-center bg-white shadow-xl rounded-lg p-8">
+    <section className="flex h-auto w-[343px] flex-col items-center justify-center rounded-lg bg-white p-8 shadow-xl">
       <Image src="/icon/logo.jpeg" alt="회사 로고" width={120} height={120} />
       <div className="w-full rounded-lg">
-        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-2 mt-2">
+        <form onSubmit={handleSubmit(onSubmit)} className="mt-2 flex flex-col gap-2">
           <FormInput
             id="id"
             label="아이디"
@@ -79,7 +71,7 @@ export default function SignInPage() {
           <AuthButton type="로그인" />
         </form>
 
-        <Link href="signup" className="text-[#3b82f6] block text-center mt-4 hover:underline">
+        <Link href="signup" className="mt-4 block text-center text-[#3b82f6] hover:underline">
           회원가입
         </Link>
       </div>


### PR DESCRIPTION
## 🔄 관련 이슈 / #15 

## 🔨 주요 변경 사항
- [ ] 기존에 accessToken과 함께 저장하던 expiresAt 유툥기한 값을 삭제했습니다.
- [ ] 루트 페이지 컴포넌트인, Home에서 쿠키를 확인해 accessToken가 있으면 /boards 페이지로, 없다면 /signin 페이지로 보냅니다.
- [ ] authInstance.intercept에서 accessToken을 재갱신 하는 로직을 서버와 클라이언트를 구분해 로직을 분리해주었습니다.
(서버 -> 쿠키에 접근 가능하니 바로 백엔드로 요청, 클라이언트 -> refresh api route로 요청하고 받은 accessToken을 로컬 스토리지에 재갱신)
- [ ] 로그아웃 기능 구현을 위해서 Header.tsx에서 Profile을 눌렀을 떄  Dropdown이 뜨도록 ui 구현한 작업이 이번 이슈에 포함됩니다.
- [ ] 로그아웃 버튼을 누르면 쿠키에 token을 삭제하기 위해 logout 전용 api route로 POST요청을 보내게 했습니다.(HtpOnly가 붙어있어 client에서 삭제 못하기 때문)( 흐름 : client -> postLogout() 호출 -> api route POST 요청 -> 서버가 브라우저에 cookie 제거!)

## 🧪 테스트 사항
- [x] 로그아웃을 누르면, 브라우저 스토리지에 인증과 관련한 어떤 데이터도 없어야 합니다.
- [x] 로그아웃을 누르면, 안내 메시지와 함께 /signin 페이지로 리다이렉트 됩니다.

## Preview
![로그아웃 시연](https://github.com/user-attachments/assets/eeca344d-1842-4454-8d19-7419efc233a9)
